### PR TITLE
Fix test ip address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ provisioning/scripts/deploy.sh
 NOTES.md
 utils/*
 services/casdoor/casdoor.db_orig
+
+/.idea


### PR DESCRIPTION
test_lab_core.py reads external ip from group_vars/lab.yaml, instead of the ifconfig.me webpage